### PR TITLE
add nobundle and sourcesLocation argument

### DIFF
--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -18,6 +18,7 @@ export default class Bundle extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     folder: flags.string({description: 'Subfolder to output to', required: false}),
+    sourceslocation: flags.string({description: 'Subfolder where sources are located', required: false}),
   };
 
   async run() {
@@ -28,7 +29,7 @@ export default class Bundle extends Command {
     this.log()
 
     const execTime = this.time('Execution time', Utils.headingFormat)
-    await this.bundleSources(flags.folder)
+    await this.bundleSources(flags.folder, flags.sourceslocation)
 
     const versionTime = this.time('Versioning File', Utils.headingFormat)
     await this.generateVersioningFile(flags.folder)
@@ -107,7 +108,7 @@ export default class Bundle extends Command {
     })
   }
 
-  async bundleSources(folder = '') {
+  async bundleSources(folder = '', sourcesLocation = '') {
     const basePath = process.cwd()
 
     // Make sure there isn't a built folder already
@@ -127,25 +128,47 @@ export default class Bundle extends Command {
 
     fs.mkdirSync(bundlesPath, {recursive: true})
 
-    const directoryPath = path.join(basePath, 'temp_build')
-    const promises: Promise<void>[] = fs.readdirSync(directoryPath).map(async file => {
-      const fileBundleTime = this.time(`- Building ${file}`)
+    if (sourcesLocation === '') {
+      const directoryPath = path.join(basePath, 'temp_build')
+      const promises: Promise<void>[] = fs.readdirSync(directoryPath).map(async file => {
+        const fileBundleTime = this.time(`- Building ${file}`)
 
-      Utils.copyFolderRecursive(
-        path.join(basePath, 'src', file, 'external'),
-        path.join(directoryPath, file)
-      )
+        Utils.copyFolderRecursive(
+          path.join(basePath, 'src', file, 'external'),
+          path.join(directoryPath, file)
+        )
 
-      await this.bundle(file, directoryPath, bundlesPath)
+        await this.bundle(file, directoryPath, bundlesPath)
 
-      Utils.copyFolderRecursive(
-        path.join(basePath, 'src', file, 'includes'),
-        path.join(bundlesPath, file)
-      )
-      fileBundleTime.end()
-    })
+        Utils.copyFolderRecursive(
+          path.join(basePath, 'src', file, 'includes'),
+          path.join(bundlesPath, file)
+        )
+        fileBundleTime.end()
+      })
 
-    await Promise.all(promises)
+      await Promise.all(promises)
+    } else {
+      const directoryPath = path.join(basePath, 'temp_build', sourcesLocation)
+      const promises: Promise<void>[] = fs.readdirSync(directoryPath).map(async file => {
+        const fileBundleTime = this.time(`- Building ${file}`)
+
+        Utils.copyFolderRecursive(
+          path.join(basePath, 'src', sourcesLocation, file, 'external'),
+          path.join(directoryPath, file)
+        )
+
+        await this.bundle(file, directoryPath, bundlesPath)
+
+        Utils.copyFolderRecursive(
+          path.join(basePath, 'src', sourcesLocation, file, 'includes'),
+          path.join(bundlesPath, file)
+        )
+        fileBundleTime.end()
+      })
+
+      await Promise.all(promises)
+    }
 
     bundleTime.end()
 

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -12,6 +12,7 @@ export default class Serve extends Command {
   static flags = {
     help: flags.help({char: 'h'}),
     port: flags.integer({char: 'p', default: 8080}),
+    nobundle: flags.boolean({description: 'Prevent bundling when launching serve. Will use existing bundle. Make sure that it\'s present.', default: false}),
   }
 
   async run() {
@@ -20,10 +21,13 @@ export default class Serve extends Command {
     // eslint-disable-next-line no-console
     console.clear()
 
-    this.log(chalk.underline.blue('Building Sources'))
+    if (flags.nobundle) {
+      this.log(chalk.underline.blue('nobundle argument detected => NOT building sources, make sure that a bundle is present.'))
+    } else {
+      this.log(chalk.underline.blue('Building Sources'))
+      await Bundle.run([])
+    }
 
-    // Make sure the repo is bundled
-    await Bundle.run([])
     this.log()
     this.log(chalk.underline.blue('Starting Server on port ' + flags.port))
 
@@ -57,9 +61,10 @@ export default class Serve extends Command {
 
         this.log(chalk.underline.blue('Building Sources'))
 
-        // Make sure the repo is bundled
-        // eslint-disable-next-line no-await-in-loop
-        await Bundle.run()
+        if (!flags.nobundle) {
+          // eslint-disable-next-line no-await-in-loop
+          await Bundle.run([])
+        }
         this.log()
         this.log(chalk.underline.blue('Starting Server on port ' + flags.port))
 


### PR DESCRIPTION
This pull adds the following arguments:

 **--sourcesLocation** to **bundle** command so that you can direct the script to a specific folder where sources are located, not only under the root of the repo as shown in this [exemple](https://user-images.githubusercontent.com/1227722/112720501-11b7e080-8eff-11eb-95e5-80e1c683e64c.png).
Can be useful for repo clarity when developing abstract sources

**--nobundle** to **serve** command so that it does not bundle again the files since it can not use arguments for bundle. The old all in one serve command can still be used like this:
"serve": "paperback bundle --sourceslocation=sources && paperback serve -p 8000 --nobundle"

Code can surely be improved, I'm not experienced with commands environment in node. Feel free to modify it to make it cleaner.